### PR TITLE
Bump PHP version to 8.1 for legacy compatibility reasons.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,14 +3,14 @@
     "description": "Yii2 OAuth2 server implementation of https://oauth2.thephpleague.com/",
     "type": "library",
     "require": {
-        "php": ">=7.1.0",
+        "php": "^8.1",
 
         "jc-it/yii2-blameable-behavior": "^1.0.0",
         "jc-it/yii2-timestamp-behavior": "^1.0.0",
         "kartik-v/yii2-builder": "^1.6.5",
         "kartik-v/yii2-icons": "^1.4.5",
         "league/oauth2-server": "^7.4.0",
-        "lcobucci/jwt": "~3.3.3",
+        "lcobucci/jwt": "^4.3.0",
         "sam-it/yii2-magic": "^2.2.0",
         "unclead/yii2-multiple-input": "^2.21.3",
         "yiisoft/yii2-bootstrap4": "~2.0.1",


### PR DESCRIPTION
For Tilburg/CIAW I need a version 2.0 of this, since the previous versions were still for PHP 7.3.